### PR TITLE
Better language switcher with user's language detection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="app">
-        <LanguageSwitch/>
+        <LanguageSwitch />
         <div :class="loading ? 'loading' : ''">
             <a class="bugs" href="https://github.com/jirkavrba/folding-stats/issues/new" target="_blank">
                 {{ $t('issues') }}
@@ -74,8 +74,14 @@
     import messages from "./messages";
     import universities from "./universities";
 
+    const userLang = localStorage.lang
+        || (navigator.languages
+            ? navigator.languages[0]
+            : (navigator.language || navigator.userLanguage));
+
     const i18n = new VueI18n({
-        locale: "cz",
+        locale: userLang?.substring(0, 2),
+        fallbackLocale: "en",
         messages: messages
     })
 

--- a/src/components/LanguageSwitch.vue
+++ b/src/components/LanguageSwitch.vue
@@ -1,23 +1,103 @@
 <template>
-    <div class="language-switch">
-        <select v-model="$i18n.locale">
-            <option v-for="(lang, i) in langs" :key="`Lang${i}`" :value="lang">{{ lang }}</option>
-        </select>
+    <div class="switch">
+        <div class="switch__box" tabindex="1">
+            <div v-for="(lang, i) in $i18n.availableLocales" class="switch__value" :key="`LangCurrent${i}`">
+                <input class="switch__input" type="radio" v-model="$i18n.locale" :id="i" :value="lang" name="language" :checked="`${$i18n.locale === lang} ? checked : ''`">
+                <p class="switch__input-text">{{ lang.toUpperCase() }}</p>
+            </div>
+            <img class="switch__arrow" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAwIDEwMDAiPjxkZWZzLz48cGF0aCBkPSJNNTAwIDc3NUwxMCAyODdsNjQtNjIgNDI2IDQyNSA0MjYtNDI1IDY0IDYyLTQ5MCA0ODh6Ii8+PC9zdmc+" alt="" aria-hidden="true">
+        </div>
+        <ul class="switch__list">
+            <li v-for="(lang, i) in $i18n.availableLocales" :key="`LangSelect${i}`" v-on:click="saveLanguage(lang)">
+                <label class="switch__option" :for="i" aria-hidden="true">{{ lang.toUpperCase() }}</label>
+            </li>
+        </ul>
     </div>
 </template>
 
 <script>
     export default {
-        data () {
-            return { langs: ['cz', 'en'] }
+        methods: {
+            saveLanguage(lang) {
+                localStorage.lang = lang;
+            }
         }
     }
 </script>
 
 <style>
-    .language-switch {
+    .switch {
         position: fixed;
         top: 1rem;
         right: 1rem;
+        width: calc(2em + 50px);
+        font-size: 1.25rem;
+        color: #999;
+    }
+
+    .switch__box {
+        position: relative;
+        cursor: pointer;
+        outline: none;
+        box-shadow: 0 10px 15px -2px rgba(0, 0, 0, 0.15);
+    }
+
+    .switch__box:focus .switch__arrow {
+        transform: translateY(-50%) rotate(180deg);
+        top: calc(50%);
+    }
+
+    .switch__value {
+        display: flex;
+    }
+
+    .switch__input {
+        display: none;
+    }
+
+    .switch__input-text {
+        display: none;
+        width: 100%;
+        margin: 0;
+        padding: 10px;
+        background: #fff;
+    }
+
+    .switch__input:checked + .switch__input-text {
+        display: block;
+    }
+
+    .switch__arrow {
+        position: absolute;
+        top: calc(50% - 8px);
+        right: 10px;
+        width: 16px;
+        height: 16px;
+        opacity: 0.5;
+        transition: all 0.25s ease;
+    }
+
+    .switch__list {
+        position: absolute;
+        width: 100%;
+        padding: 0;
+        list-style: none;
+        opacity: 0;
+        box-shadow: 0 10px 15px -2px rgba(0, 0, 0, 0.15);
+    }
+    .switch__box:focus + .switch__list {
+        opacity: 1;
+        animation-name: none;
+    }
+
+    .switch__option {
+        display: block;
+        padding: 10px;
+        background-color: #fff;
+    }
+
+    .switch__option:hover {
+        color: #f00;
+        cursor: pointer;
     }
 </style>

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,5 +1,5 @@
 export default {
-    cz: {
+    cs: {
         issues: "Návrhy a chyby",
         teams: "Jednotlivé týmy",
         institutions: "Akademické instituce",


### PR DESCRIPTION
# What was changed

## UX/UI

I've redesigned the language switcher to replace the old unstyled HTML-only version for a more consistent UX and UI.

## Functionality

Before when the page loaded, Czech language was set after every load with no persistence.  
Right now the locale is based on JavaScript `navigator` API with fall back to English. When a user selects a language manually, the choice is saved to the `localStorage` and taken in mind next time the page is visited. This fixes issue #12.

## Misc

Language code 'cz' was changed to 'cs' to follow the ISO-639-1 standard.

## Example

![language switcher](https://user-images.githubusercontent.com/15214494/79933636-e1df9d80-8450-11ea-9e0c-6a43b2cb25ad.gif)